### PR TITLE
Arrange Raw import as in scapy>=2.4

### DIFF
--- a/SAPanonGWv2.py
+++ b/SAPanonGWv2.py
@@ -7,8 +7,8 @@ from ansicolor import red, green, blue, yellow, cyan, magenta
 from pysap.SAPNI import SAPNI, SAPNIStreamSocket
 from pysap.SAPDiag import SAPDiag, SAPDiagItem
 from scapy.supersocket import StreamSocket
-from scapy.layers.inet import TCP, Raw
-from scapy.packet import bind_layers
+from scapy.layers.inet import TCP
+from scapy.packet import bind_layers, Raw
 from scapy.all import hexdump, raw
 from scapy.config import conf
 from struct import *


### PR DESCRIPTION
Similar to what was reported in https://github.com/gelim/sap_ms/pull/2, in Scapy >= 2.4, the `Raw` class is no longer available in `scapy.layers.inet` and instead it should be imported from where it is defined `scapy.packet`.